### PR TITLE
Add dot on Ruby code comment

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ var fun = function lang(l) {
 ```
 
 ```ruby
-# Ruby code with syntax highlighting
+# Ruby code with syntax highlighting.
 GitHubPages::Dependencies.gems.each do |gem, version|
   s.add_dependency(gem, "= #{version}")
 end


### PR DESCRIPTION
JavaScript code has one, if Ruby doesn't have one it makes it look asymmetric.

![image](https://user-images.githubusercontent.com/71897736/157514393-cd9cb471-9a1a-4f8e-a733-43bd68cd0c14.png)
